### PR TITLE
Fix forwarding trie and default response

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,8 @@ package config
 import (
     "bufio"
     "fmt"
-    
+
+    "net"
     "os"
     "strings"
 
@@ -24,11 +25,14 @@ type Upstream struct {
     V6      bool     `yaml:"v6"`
     File    string   `yaml:"file,omitempty"`
     Entries []string `yaml:"-"`
+    Trie    *Trie    `yaml:"-"`
 }
 
 type DefaultConfig struct {
-    ChinaIPCidrsFile string     `yaml:"china_ip_cidrs_file"`
-    Upstreams        []Upstream `yaml:"upstreams"`
+    ChinaIPCidrsFile string       `yaml:"china_ip_cidrs_file"`
+    Domestic         []Upstream   `yaml:"domestic"`
+    Foreign          []Upstream   `yaml:"foreign"`
+    CIDRs            []*net.IPNet `yaml:"-"`
 }
 
 type HostConfig struct {
@@ -80,6 +84,12 @@ func LoadConfig(path string) (*Config, error) {
     if cfg.Forward == nil {
         cfg.Forward = make([]Upstream, 0)
     }
+    if cfg.Default.Domestic == nil {
+        cfg.Default.Domestic = make([]Upstream, 0)
+    }
+    if cfg.Default.Foreign == nil {
+        cfg.Default.Foreign = make([]Upstream, 0)
+    }
 
     // 3. 只有在 file 字段非空时，才真正去加载文件
     if cfg.Host.File != "" {
@@ -108,6 +118,21 @@ func LoadConfig(path string) (*Config, error) {
         } else {
             cfg.Forward[i].Entries = make([]string, 0)
         }
+        trie := NewTrie()
+        for _, entry := range cfg.Forward[i].Entries {
+            trie.Insert(entry)
+        }
+        cfg.Forward[i].Trie = trie
+    }
+
+    if cfg.Default.ChinaIPCidrsFile != "" {
+        cidrs, err := readCIDRs(cfg.Default.ChinaIPCidrsFile)
+        if err != nil {
+            return nil, fmt.Errorf("解析 china_ip_cidrs_file 失败: %w", err)
+        }
+        cfg.Default.CIDRs = cidrs
+    } else {
+        cfg.Default.CIDRs = make([]*net.IPNet, 0)
     }
 
     return &cfg, nil
@@ -168,4 +193,21 @@ func readLines(path string) ([]string, error) {
         return nil, err
     }
     return lines, nil
+}
+
+// readCIDRs parses CIDR blocks from file
+func readCIDRs(path string) ([]*net.IPNet, error) {
+    lines, err := readLines(path)
+    if err != nil {
+        return nil, err
+    }
+    var cidrs []*net.IPNet
+    for _, line := range lines {
+        if _, ipnet, err := net.ParseCIDR(line); err == nil {
+            cidrs = append(cidrs, ipnet)
+        } else {
+            return nil, fmt.Errorf("invalid CIDR %s: %w", line, err)
+        }
+    }
+    return cidrs, nil
 }

--- a/core/default.go
+++ b/core/default.go
@@ -1,0 +1,109 @@
+package core
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+	"zzproxy/config"
+)
+
+// DefaultQuery sends the request to domestic DNS servers first. If the returned
+// IPs fall within the configured China CIDR list, their response is used.
+// Otherwise it falls back to foreign DNS servers.
+func DefaultQuery(name string, qtype uint16, cfg *config.Config) (*dns.Msg, error) {
+	// try domestic servers
+	for i := range cfg.Default.Domestic {
+		resp, err := queryUpstream(&cfg.Default.Domestic[i], name, qtype)
+		if err != nil {
+			continue
+		}
+		if qtype == dns.TypeA || qtype == dns.TypeAAAA {
+			if resp != nil && responseInCIDRs(resp.Answer, cfg.Default.CIDRs) {
+				return resp, nil
+			}
+		} else if resp != nil {
+			return resp, nil
+		}
+	}
+
+	// fallback to foreign servers
+	for i := range cfg.Default.Foreign {
+		resp, err := queryUpstream(&cfg.Default.Foreign[i], name, qtype)
+		if err != nil {
+			continue
+		}
+		if resp != nil {
+			return resp, nil
+		}
+	}
+	return nil, fmt.Errorf("all default upstreams failed")
+}
+
+func queryUpstream(up *config.Upstream, name string, qtype uint16) (*dns.Msg, error) {
+	if up.Server == "" {
+		return nil, fmt.Errorf("empty upstream server")
+	}
+	msg := new(dns.Msg)
+	msg.SetQuestion(dns.Fqdn(name), qtype)
+
+	u, err := url.Parse(up.Server)
+	if err != nil {
+		return nil, fmt.Errorf("invalid upstream URI '%s': %w", up.Server, err)
+	}
+
+	client := new(dns.Client)
+	client.ReadTimeout = 2 * time.Second
+	client.WriteTimeout = 2 * time.Second
+
+	var network, address string
+	switch strings.ToLower(u.Scheme) {
+	case "udp":
+		network = "udp"
+		address = u.Host
+	case "tls", "dot":
+		network = "tcp-tls"
+		address = u.Host
+		client.TLSConfig = &tls.Config{
+			InsecureSkipVerify: false,
+			ServerName:         u.Hostname(),
+		}
+	default:
+		return nil, fmt.Errorf("unsupported protocol '%s'", u.Scheme)
+	}
+
+	resp, _, err := client.Exchange(msg, address)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func responseInCIDRs(rrs []dns.RR, cidrs []*net.IPNet) bool {
+	for _, rr := range rrs {
+		switch v := rr.(type) {
+		case *dns.A:
+			if ipInCIDRs(v.A, cidrs) {
+				return true
+			}
+		case *dns.AAAA:
+			if ipInCIDRs(v.AAAA, cidrs) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func ipInCIDRs(ip net.IP, cidrs []*net.IPNet) bool {
+	for _, c := range cidrs {
+		if c.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/server/server.go
+++ b/server/server.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"log"
-	
+
 	"net/http"
 	"strings"
 	"time"
@@ -13,7 +13,8 @@ import (
 	"github.com/miekg/dns"
 	gocache "github.com/patrickmn/go-cache"
 )
-var cache     = gocache.New(60*time.Second, 120*time.Second) // 默认缓存 TTL 60s, 清理间隔 120s
+
+var cache = gocache.New(60*time.Second, 120*time.Second) // 默认缓存 TTL 60s, 清理间隔 120s
 // Run 启动 DNS 服务和 API HTTP 服务
 func Run(cfg *config.Config) {
 	// 注册 DNS 请求处理器
@@ -60,55 +61,63 @@ func StartServer(netType, addr string) error {
 }
 
 func handleDNS(w dns.ResponseWriter, r *dns.Msg, cfg *config.Config) {
-    m := new(dns.Msg)
-    m.SetReply(r)
-    q := r.Question[0]
-    name := strings.TrimSuffix(q.Name, ".")
+	m := new(dns.Msg)
+	m.SetReply(r)
+	q := r.Question[0]
+	name := strings.TrimSuffix(q.Name, ".")
 
-    // 1. 缓存
-    key := q.Name + "|" + dns.TypeToString[q.Qtype]
-    if cached, found := cache.Get(key); found {
-        if msg, ok := cached.(*dns.Msg); ok {
-            msg.Id = r.Id
-            w.WriteMsg(msg)
-            return
-        }
-    }
+	// 1. 缓存
+	key := q.Name + "|" + dns.TypeToString[q.Qtype]
+	if cached, found := cache.Get(key); found {
+		if msg, ok := cached.(*dns.Msg); ok {
+			msg.Id = r.Id
+			w.WriteMsg(msg)
+			return
+		}
+	}
 
-    // 2. 黑名单
-    if core.BlacklistCheck(name, cfg.Blacklist.Entries) {
-        m.Rcode = dns.RcodeRefused
-        w.WriteMsg(m)
-        return
-    }
+	// 2. 黑名单
+	if core.BlacklistCheck(name, cfg.Blacklist.Entries) {
+		m.Rcode = dns.RcodeRefused
+		w.WriteMsg(m)
+		return
+	}
 
-    // 3. Host 配置
-    if rr, ok := core.HostLookup(name, cfg.Host.Hosts, q); ok {
-        m.Answer = append(m.Answer, rr)
-        cache.Set(key, m.Copy(), gocache.DefaultExpiration)
-        w.WriteMsg(m)
-        return
-    }
+	// 3. Host 配置
+	if rr, ok := core.HostLookup(name, cfg.Host.Hosts, q); ok {
+		m.Answer = append(m.Answer, rr)
+		cache.Set(key, m.Copy(), gocache.DefaultExpiration)
+		w.WriteMsg(m)
+		return
+	}
 
-    // 4. 上游转发（调用 core.ForwardQuery）
-    resp, err := core.ForwardQuery(name, q.Qtype, cfg)
-    if err != nil {
-        log.Printf("转发失败: %v", err)
-        m.Rcode = dns.RcodeServerFailure
-        w.WriteMsg(m)
-        return
-    }
-    // 如果 resp == nil，表示未匹配任何上游，交由后续逻辑处理
-    if resp == nil {
-        // 交给下一个处理器或默认逻辑（例如 NXDOMAIN）
-        // 这里简单返回 NameError
-        
-    }
-	
-    // 5. 填充并缓存
-    m.Answer = resp.Answer
-    m.Extra = resp.Extra
-    m.Rcode = resp.Rcode
-    cache.Set(key, m.Copy(), gocache.DefaultExpiration)
-    w.WriteMsg(m)
+	// 4. 上游转发（调用 core.ForwardQuery）
+	resp, err := core.ForwardQuery(name, q.Qtype, cfg)
+	if err != nil {
+		log.Printf("转发失败: %v", err)
+		m.Rcode = dns.RcodeServerFailure
+		w.WriteMsg(m)
+		return
+	}
+	if resp == nil {
+		resp, err = core.DefaultQuery(name, q.Qtype, cfg)
+		if err != nil {
+			log.Printf("默认查询失败: %v", err)
+			m.Rcode = dns.RcodeServerFailure
+			w.WriteMsg(m)
+			return
+		}
+		if resp == nil {
+			m.Rcode = dns.RcodeNameError
+			w.WriteMsg(m)
+			return
+		}
+	}
+
+	// 5. 填充并缓存
+	m.Answer = resp.Answer
+	m.Extra = resp.Extra
+	m.Rcode = resp.Rcode
+	cache.Set(key, m.Copy(), gocache.DefaultExpiration)
+	w.WriteMsg(m)
 }


### PR DESCRIPTION
## Summary
- add `Trie` field in `Upstream` and build it during config loading
- return NXDOMAIN if no upstream matches
- add domestic/foreign upstream groups and CIDR check in default query

## Testing
- `go vet ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68662e7d50708328856c9c36cbe795fe